### PR TITLE
Rule/reverse card

### DIFF
--- a/include/game_manager.h
+++ b/include/game_manager.h
@@ -23,8 +23,15 @@ namespace MyUno
 		void BuildPlayerHand(shared_ptr<Player> player);
 		void RandomizePlayerOrder();
 		bool isRunning;
-	public:
 		GameManager();
+	public:
+		static GameManager& GetInstance()
+		{
+			static GameManager instance;
+			return instance;
+		}
+		GameManager(GameManager const&) = delete;
+		void operator=(GameManager const&) = delete;
 		/// <summary>
 		/// End the main game loop by setting IsRunning to false. The next time the game loop
 		/// is evaluated it'll evaluate to false

--- a/include/game_manager.h
+++ b/include/game_manager.h
@@ -8,6 +8,7 @@
 using namespace std;
 namespace MyUno
 {
+	enum Increment{Positive=1, Negative=-1};
 	class Player;
 	/// <summary>
 	/// Orchestrates the game.
@@ -23,6 +24,8 @@ namespace MyUno
 		void BuildPlayerHand(shared_ptr<Player> player);
 		void RandomizePlayerOrder();
 		bool isRunning;
+		int currentPlayerId;
+		Increment increment;
 		GameManager();
 	public:
 		static GameManager& GetInstance()
@@ -57,6 +60,12 @@ namespace MyUno
 		shared_ptr<CardContainer> GetDiscardPile() { return discardPile; }
 		void PlayCard(shared_ptr<Player> player, shared_ptr<Card> card);
 		shared_ptr<Card> DealCardTo(shared_ptr<Player> player);
+		void RevertOrderOfMatch();
+
+		shared_ptr<Player> GetCurrentPlayer();
+		shared_ptr<Player> GetPreviousPlayer();
+		shared_ptr<Player> GetNextPlayer();
+		void EndTurn();
 	};
 }
 

--- a/src/game_manager.cpp
+++ b/src/game_manager.cpp
@@ -61,6 +61,7 @@ void MyUno::GameManager::PlayCard(shared_ptr<Player> player, shared_ptr<Card> ch
 {
 	player->RemoveCardFromHand(chosenCard);
 	discardPile->Add(chosenCard);
+	chosenCard->ExecuteAction();
 }
 
 shared_ptr<Card> MyUno::GameManager::DealCardTo(shared_ptr<Player> player)

--- a/src/game_manager.cpp
+++ b/src/game_manager.cpp
@@ -2,12 +2,15 @@
 #include <iostream>
 #include <random>
 #include "player.h"
+#include "random.h"
 using namespace MyUno;
 
 
 GameManager::GameManager()
 	:isRunning(false),
-	windowManager(WindowSystem(*this))
+	windowManager(WindowSystem(*this)),
+	currentPlayerId(0),
+	increment(Positive)
 {
 }
 
@@ -35,9 +38,7 @@ void MyUno::GameManager::BuildPlayerHand(shared_ptr<Player> player)
 
 void MyUno::GameManager::RandomizePlayerOrder()
 {
-	std::random_device rd;
-	std::mt19937 g(rd());
-	std::shuffle(players.begin(), players.end(), g);
+//3	std::shuffle(players.begin(), players.end(), MyRandom::GetInstance().GetGenerator());
 }
 
 void MyUno::GameManager::BeginMatch(const vector<string>& playerNames)
@@ -81,4 +82,83 @@ shared_ptr<Card> MyUno::GameManager::DealCardTo(shared_ptr<Player> player)
 	}
 	player->GiveCard(card);
 	return card;
+}
+
+void MyUno::GameManager::RevertOrderOfMatch()
+{
+	if (increment == Positive) 
+	{
+		increment = Negative;
+		return;
+	}
+	if (increment == Negative)
+	{
+		increment = Positive;
+		return;
+	}
+}
+
+shared_ptr<Player> MyUno::GameManager::GetCurrentPlayer()
+{
+	return players[currentPlayerId];
+}
+
+shared_ptr<Player> MyUno::GameManager::GetPreviousPlayer()
+{
+	if (increment == Positive)
+	{//incremento positivo, overflow no começo
+		if (currentPlayerId - Positive < 0) {
+			return players[players.size()-1];
+		}
+		else {
+			return players[currentPlayerId - Positive];
+		}
+	}
+	else
+	{
+		if (currentPlayerId - Negative >= players.size()) {
+			return players[0];
+		}
+		else {
+			return players[currentPlayerId - Negative];
+		}
+	}
+}
+
+shared_ptr<Player> MyUno::GameManager::GetNextPlayer()
+{
+	if (increment == Positive)
+	{//Incremento positivo, overflow no final
+		if (currentPlayerId + Positive >= players.size()) {
+			return players[0];
+		}
+		else {
+			return players[currentPlayerId + Positive];
+		}
+	}
+	else
+	{//incremento negativo, overflow no inicio
+		if (currentPlayerId + Negative < 0) {
+			return players[players.size() - 1];
+		}
+		else {
+			return players[currentPlayerId + Negative];
+		}
+	}
+}
+
+void MyUno::GameManager::EndTurn()
+{
+	currentPlayerId = currentPlayerId + increment;
+	if (currentPlayerId < 0)
+	{
+		currentPlayerId = players.size() - 1;
+		return;
+	}
+	if (currentPlayerId >= players.size())
+	{
+		currentPlayerId = 0;
+		return;
+	}
+		
 }

--- a/src/game_manager.cpp
+++ b/src/game_manager.cpp
@@ -86,16 +86,8 @@ shared_ptr<Card> MyUno::GameManager::DealCardTo(shared_ptr<Player> player)
 
 void MyUno::GameManager::RevertOrderOfMatch()
 {
-	if (increment == Positive) 
-	{
-		increment = Negative;
-		return;
-	}
-	if (increment == Negative)
-	{
-		increment = Positive;
-		return;
-	}
+	increment = increment == Positive ? Negative : Positive;
+	
 }
 
 shared_ptr<Player> MyUno::GameManager::GetCurrentPlayer()

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -4,7 +4,6 @@ using namespace std;
 using namespace MyUno;
 
 int main(){
-    GameManager manager;
-    manager.GameLoop();
+    GameManager::GetInstance().GameLoop();
     return 0;    
 }

--- a/src/match_window.cpp
+++ b/src/match_window.cpp
@@ -32,57 +32,61 @@ MyUno::MatchWindow::MatchWindow(WindowSystem& manager)
 
 void MyUno::MatchWindow::Draw()
 {
-    //foreach player
-    auto players = windowSystem.gameManager.GetPlayers();
-    for(int i=0; i<players.size(); i++)
-    { 
-        shared_ptr<Player> previousPlayer = i > 0 ? players[i - 1] : players[players.size()-1];
-        shared_ptr<Player> currentPlayer = players[i];
-        shared_ptr<Player> nextPlayer = i < players.size() - 1 ? players[i + 1] : players[0];
-        //clears the screen
-        system("cls");
-        //print it's cards
-        vector<shared_ptr<Card>> cardsInHand = currentPlayer->GetCards();
-        cout << "previous player: " << previousPlayer->name << endl;
-        cout << "current player (you): " << currentPlayer->name << endl;
-        cout << "next player: " << nextPlayer->name << endl;
-        cout << "Your hand: ";
-        for (auto cardsIt = cardsInHand.begin(); cardsIt != cardsInHand.end(); ++cardsIt)
-        {
-            shared_ptr<Card> currentCard = *cardsIt;
-            shared_ptr<CardView> cardView = GetCardView(currentCard->type);
-            cardView->Draw(currentCard);
-        }
-        cout << endl;
-        //prints the top card on the discard pile
-        std::shared_ptr<Card> topDiscardPile = windowSystem.gameManager.GetDiscardPile()->Top();
-        cout << "Discard Pile top: ";
-        if (topDiscardPile != nullptr)
-        {
-            GetCardView(topDiscardPile->type)->Draw(topDiscardPile);
-        }
-        else
-        {
-            cout << "Is empty.";
-        }
-        cout << endl;
-        if (currentPlayer->CanPlayAnyCard(topDiscardPile.get()))
-        {
-            auto chosenCard = ChooseCard(cardsInHand, topDiscardPile);
-            windowSystem.gameManager.PlayCard(currentPlayer, chosenCard);
-        }
-        else
-        {
-            auto dealtCard = windowSystem.gameManager.DealCardTo(currentPlayer);
-            cout << "You got ";
-            GetCardView(dealtCard->type)->Draw(dealtCard);
-            cout << endl << "Press any key to continue.";
-            string trash;
-            cin >> trash;
-        }
+    shared_ptr<Player> currentPlayer = windowSystem.gameManager.GetCurrentPlayer();
+    shared_ptr<Player> previousPlayer = windowSystem.gameManager.GetPreviousPlayer();
+    shared_ptr<Player> nextPlayer = windowSystem.gameManager.GetNextPlayer();
+    /*auto players = windowSystem.gameManager.GetPlayers();
+    int i = currentPlayerId;*/
+
+
+    //shared_ptr<Player> previousPlayer = i > 0 ? players[i - 1] : players[players.size() - 1];
+    //shared_ptr<Player> currentPlayer = players[i];
+    //shared_ptr<Player> nextPlayer = i < players.size() - 1 ? players[i + 1] : players[0];
+    //clears the screen
+    system("cls");
+    //print it's cards
+    vector<shared_ptr<Card>> cardsInHand = currentPlayer->GetCards();
+    cout << "previous player: " << previousPlayer->name << endl;
+    cout << "current player (you): " << currentPlayer->name << endl;
+    cout << "next player: " << nextPlayer->name << endl;
+    cout << "Your hand: ";
+    for (auto cardsIt = cardsInHand.begin(); cardsIt != cardsInHand.end(); ++cardsIt)
+    {
+        shared_ptr<Card> currentCard = *cardsIt;
+        shared_ptr<CardView> cardView = GetCardView(currentCard->type);
+        cardView->Draw(currentCard);
     }
+    cout << endl;
+    //prints the top card on the discard pile
+    std::shared_ptr<Card> topDiscardPile = windowSystem.gameManager.GetDiscardPile()->Top();
+    cout << "Discard Pile top: ";
+    if (topDiscardPile != nullptr)
+    {
+        GetCardView(topDiscardPile->type)->Draw(topDiscardPile);
+    }
+    else
+    {
+        cout << "Is empty.";
+    }
+    cout << endl;
+    if (currentPlayer->CanPlayAnyCard(topDiscardPile.get()))
+    {
+        auto chosenCard = ChooseCard(cardsInHand, topDiscardPile);
+        windowSystem.gameManager.PlayCard(currentPlayer, chosenCard);
+    }
+    else
+    {
+        auto dealtCard = windowSystem.gameManager.DealCardTo(currentPlayer);
+        cout << "You got ";
+        GetCardView(dealtCard->type)->Draw(dealtCard);
+        cout << endl << "Press any key to continue.";
+        string trash;
+        cin >> trash;
+    }
+    windowSystem.gameManager.EndTurn();
 
 }
+
 shared_ptr<Card> MyUno::MatchWindow::ChooseCard(const vector<shared_ptr<Card>>& cardsInHand, const std::shared_ptr<Card>& topDiscardPile)
 {
     bool cardCantBePlayed = true;
@@ -128,5 +132,7 @@ int MatchWindow::AskForCard(const vector<shared_ptr<Card>>& cardsInHand)
     }
     return cardToPlayIndex;
 }
+
+
 
 

--- a/src/match_window.cpp
+++ b/src/match_window.cpp
@@ -66,14 +66,13 @@ void MyUno::MatchWindow::Draw()
             cout << "Is empty.";
         }
         cout << endl;
-        //TODO: Verificar se há possibilidade de jogar alguma carta
         if (currentPlayer->CanPlayAnyCard(topDiscardPile.get()))
-        {//TODO: Se houver então pede pro player jogar
+        {
             auto chosenCard = ChooseCard(cardsInHand, topDiscardPile);
             windowSystem.gameManager.PlayCard(currentPlayer, chosenCard);
         }
         else
-        {//TODO: Se não houver pede pro gameManager dar carta pro player
+        {
             auto dealtCard = windowSystem.gameManager.DealCardTo(currentPlayer);
             cout << "You got ";
             GetCardView(dealtCard->type)->Draw(dealtCard);

--- a/src/match_window.cpp
+++ b/src/match_window.cpp
@@ -21,10 +21,6 @@ shared_ptr<CardView> MyUno::MatchWindow::GetCardView(MyUno::Type type)
     throw std::logic_error("can't find a processor. There must be a processor for each type. Take a look at the ctor of MatchWindow");
 }
 
-
-
-
-
 MyUno::MatchWindow::MatchWindow(WindowSystem& manager)
     : Window(manager)
 {

--- a/src/reverse_card.cpp
+++ b/src/reverse_card.cpp
@@ -8,7 +8,12 @@ ReverseCard::ReverseCard(Color color)
 
 bool MyUno::ReverseCard::CanBePlayed(const Card* topDiscardPileCard) const
 {
-	return false;
+	//is there any card?
+	bool isEmpty = topDiscardPileCard == nullptr;
+	//Is a numeric card?
+	bool isReverse = !isEmpty && dynamic_cast<const ReverseCard*>(topDiscardPileCard) != nullptr;
+	bool isSameColor = !isEmpty && topDiscardPileCard->color == this->color;
+	return isReverse || isSameColor || isEmpty;
 }
 
 void MyUno::ReverseCard::ExecuteAction()

--- a/src/reverse_card.cpp
+++ b/src/reverse_card.cpp
@@ -1,4 +1,5 @@
 #include "reverse_card.h"
+#include "game_manager.h"
 using namespace MyUno;
 
 ReverseCard::ReverseCard(Color color)
@@ -18,4 +19,5 @@ bool MyUno::ReverseCard::CanBePlayed(const Card* topDiscardPileCard) const
 
 void MyUno::ReverseCard::ExecuteAction()
 {
+	GameManager::GetInstance().RevertOrderOfMatch();
 }


### PR DESCRIPTION
Para implementar o reverse movi o conhecimento da ordem de jogar pra dentro do game manager, que também controla a direção que a partida avança. O campo increment controla a direção do incremento. O matchWindow só consulta o gameManager e avisa que o turno acabou. No momento a randomização de ordem de jogadores está desativada para facilitar debugging dessa questão de revert.


Outras mudanças: o randomizador de ordem de jogada usa o random global que eu criei.